### PR TITLE
Allow configuring TLS versions for transports

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -91,6 +91,8 @@ type Config struct {
 	LogMaxBackups            int                         `toml:"log_files_max_backups"`
 	TLSDisableSessionTickets bool                        `toml:"tls_disable_session_tickets"`
 	TLSCipherSuite           []uint16                    `toml:"tls_cipher_suite"`
+	TLSMinVersion            string                      `toml:"tls_min_version"`
+	TLSMaxVersion            string                      `toml:"tls_max_version"`
 	TLSKeyLogFile            string                      `toml:"tls_key_log_file"`
 	NetprobeAddress          string                      `toml:"netprobe_address"`
 	NetprobeTimeout          int                         `toml:"netprobe_timeout"`


### PR DESCRIPTION
## Summary
- add configuration options for tls_min_version and tls_max_version
- ensure xtransport honors the configured TLS versions, including HTTP/3 gating and cipher suite handling

## Testing
- go test ./... *(fails: TestNewSource expectations about encoded signatures)*
