### PR TITLE
Document TLS version configuration for DoH

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@ deterministic, non-deterministic with 8-byte tweak, and extended
 non-deterministic with 16-byte tweak.
  - Enhanced pattern rule documentation with better examples.
  - Fixed an issue where nil client addresses could cause crashes.
+ - Added `tls_min`/`tls_max` configuration options for DoH to control the
+   supported TLS versions, defaulting to TLS 1.3 only and documenting how they
+   interact with `tls_cipher_suite` and HTTP/3.
 
 # Version 2.1.13
  - Fixed race conditions in WebSocket handling for the monitoring dashboard,

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Available as source code and pre-built binaries for most operating systems and a
 
 ## Features
 
-* DNS traffic encryption and authentication. Supports DNS-over-HTTPS (DoH) using TLS 1.3 and QUIC, DNSCrypt, Anonymized DNS and ODoH
+* DNS traffic encryption and authentication. Supports DNS-over-HTTPS (DoH) using TLS 1.3 and QUIC by default, with optional TLS version tuning via `tls_min`/`tls_max`, plus DNSCrypt, Anonymized DNS and ODoH
 * Client IP addresses can be hidden using Tor, SOCKS proxies or Anonymized DNS relays
 * DNS query monitoring, with separate log files for regular and suspicious queries
 * Filtering: block ads, malware, and other unwanted content. Compatible with all DNS services

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -274,6 +274,16 @@ cert_refresh_delay = 240
 # tls_disable_session_tickets = false
 
 
+## DoH: Control the negotiated TLS versions.
+## Supported values are '1.2' and '1.3'. When unset, dnscrypt-proxy defaults to
+## TLS 1.3 only (equivalent to `tls_min = '1.3'` and `tls_max = '1.3'`).
+## HTTP/3 always uses TLS 1.3; if TLS 1.3 is disabled (for example by setting
+## `tls_max = '1.2'`), HTTP/3 will not be attempted.
+
+# tls_min = '1.3'
+# tls_max = '1.3'
+
+
 ## DoH: Use TLS 1.2 and specific cipher suite instead of the server preference
 ## 49199 = TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 ## 49195 = TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
@@ -286,7 +296,9 @@ cert_refresh_delay = 240
 ## However, this can cause issues fetching sources or connecting to some HTTP servers,
 ## and should not be set on regular CPUs.
 ##
-## Keep tls_cipher_suite undefined to let the app automatically choose secure parameters.
+## This setting only applies when TLS 1.2 is allowed (for example by setting
+## `tls_min = '1.2'`). Keep tls_cipher_suite undefined to let the app
+## automatically choose secure parameters.
 
 # tls_cipher_suite = [52392, 49199]
 


### PR DESCRIPTION
## Summary
- add `tls_min`/`tls_max` placeholders to the example configuration with notes about supported TLS versions, HTTP/3, and `tls_cipher_suite`
- mention the new TLS version controls in the README feature overview
- record the new configuration options in the ChangeLog

## Testing
- not run (documentation-only changes)
